### PR TITLE
fix: replace opencv3 with libopencv-dev in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,7 @@
 	<depend>eigen</depend>
 	<depend>geometry_msgs</depend>
 	<depend>image_transport</depend>
-	<depend>opencv3</depend>
+	<depend>libopencv-dev</depend>
 	<depend>rosconsole</depend>
 	<depend>roscpp</depend>
 	<depend>rostime</depend>


### PR DESCRIPTION
Running `rosdep install` on a package containing the charuco_detector produces the error: `charuco_detector: Cannot locate rosdep definition for [opencv3]`

Looking through the package definitions of rosdep ([here](https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml)) it seems that the correct definition for opencv should be `libopencv-dev`.
