### PR TITLE
Invert tf

### DIFF
--- a/include/charuco_detector/charuco_detector.h
+++ b/include/charuco_detector/charuco_detector.h
@@ -33,10 +33,6 @@
 #include <image_transport/image_transport.h>
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <tf2_ros/transform_broadcaster.h>
-// #include <Transform.h>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/transform_datatypes.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>   </includes>  <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 

--- a/include/charuco_detector/charuco_detector.h
+++ b/include/charuco_detector/charuco_detector.h
@@ -33,6 +33,11 @@
 #include <image_transport/image_transport.h>
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <tf2_ros/transform_broadcaster.h>
+// #include <Transform.h>
+#include <tf2/LinearMath/Transform.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/transform_datatypes.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>   </includes>  <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 
@@ -68,6 +73,8 @@ namespace charuco_detector {
 		int number_of_squares_in_x_;
 		int number_of_squares_in_y_;
 		int dictionary_id_;
+
+		bool tf_direction_invert_;
 
 		bool use_median_blur_;
 		int median_blur_k_size_;
@@ -117,6 +124,9 @@ namespace charuco_detector {
 		tf2_ros::TransformBroadcaster tf_broadcaster_;
 		geometry_msgs::TransformStamped transform_stamped_;
 		bool transform_stamped_valid_;
+		tf2::Transform transform;
+		tf2::Stamped<tf2::Transform> stamped_transform;
+		geometry_msgs::Pose inverted_pose_;
 	};
 
 }

--- a/launch/charuco_detector.launch
+++ b/launch/charuco_detector.launch
@@ -15,6 +15,9 @@
 	<arg name="image_analysis_publish_topic" default="$(arg image_topic)_charuco_detection" />
 	<arg name="charuco_pose_publish_topic" default="$(arg image_topic)_charuco_pose" />
 
+	<!-- Invert the tf to make the board the parent and camera the child-->
+	<arg name="tf_direction_invert" default="false" />
+
 	<!-- Change the charuco TF frame if you need poses to be estimated from several charuco boards -->
 	<arg name="charuco_tf_frame" default="charuco" />
 
@@ -65,6 +68,8 @@
 		<param name="camera_info_topic" type="str" value="$(arg camera_info_topic)" />
 		<param name="image_analysis_publish_topic" type="str" value="$(arg image_analysis_publish_topic)" />
 		<param name="charuco_pose_publish_topic" type="str" value="$(arg charuco_pose_publish_topic)" />
+
+		<param name="tf_direction_invert" type="bool" value="$(arg tf_direction_invert)" />
 
 		<param name="charuco_tf_frame" type="str" value="$(arg charuco_tf_frame)" />
 		<param name="sensor_frame_override" type="str" value="$(arg sensor_frame_override)" />

--- a/src/charuco_detector.cpp
+++ b/src/charuco_detector.cpp
@@ -213,7 +213,11 @@ namespace charuco_detector {
 				} else {
 					// Invert the transform so that tf goes board -> camera
 					if (!sensor_frame_override_.empty())
+					{
 						transform_stamped_.child_frame_id = sensor_frame_override_;
+					} else {
+						transform_stamped_.child_frame_id = _msg->header.frame_id;
+					}
 					transform_stamped_.header.frame_id = charuco_tf_frame_;
 
 					tf2::fromMsg(transform_stamped_.transform, transform);


### PR DESCRIPTION
Added a feature to allow the camera frame to be the child of the board frame, controlled by the 'tf_direction_invert' param. This allows multiple cameras to sync their frame off a single board.